### PR TITLE
Wrap FlexibleAppBarBottomWidget's child widget inside a MediaQuery

### DIFF
--- a/lib/utils/flexible_app_bar_widget.dart
+++ b/lib/utils/flexible_app_bar_widget.dart
@@ -24,7 +24,7 @@ class FlexibleAppBarBottomWidget extends StatelessWidget
     final builder = new Builder(
         builder: (BuildContext context) {
           savedContext = context;
-          return child;
+          return wrapInMediaQuery(child: child);
         },
         );
     new OffscreenWidgetTree(screenSize)
@@ -34,4 +34,14 @@ class FlexibleAppBarBottomWidget extends StatelessWidget
 
   @override
   Widget build(BuildContext context) => child;
+
+  Widget wrapInMediaQuery({Widget child}) {
+    return new Directionality(
+      textDirection: TextDirection.ltr,
+      child: new MediaQuery(
+        data: const MediaQueryData(),
+        child: child,
+      ),
+    );
+  }
 }


### PR DESCRIPTION
In [7e09649](https://github.com/flutter/flutter/commit/7e09649c415dde9b96a2db31a0b3633e34dc5bf4#diff-2a7352a56598405d6792eefa58fd66c7), `CircleAvatar` started to require a `MediaQuery` ancestor. Without this wrap, the application crashes on newer versions of flutter. Is there a better way of doing this? I'm quite new with flutter, so not confident enough as to this solution. Also, thanks for the talk @DroidconIT! :smile_cat: 